### PR TITLE
Fix "TypeError: Request with GET/HEAD method cannot have body."

### DIFF
--- a/server/src/services/OptionsProxy.service.ts
+++ b/server/src/services/OptionsProxy.service.ts
@@ -18,7 +18,7 @@ export const OptionsProxyService = ({ strapi }: { strapi: Core.Strapi }) => ({
     const res = await fetch(this.replaceVariables(config.fetch.url), {
       method: config.fetch.method,
       headers: this.parseStringHeaders(config.fetch.headers),
-      body: config.fetch.body ? this.replaceVariables(config.fetch.body) : '',
+      body: config.fetch.body ? this.replaceVariables(config.fetch.body) : null,
     });
 
     const response = await res.json();


### PR DESCRIPTION
The [Fetch API doesn't support passing a body for GET methods](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body:~:text=You%20cannot%20include%20a%20body%20with%20GET%20requests). NodeJS's Fetch implementation [is based on undici](https://nodejs.org/dist/latest-v22.x/docs/api/globals.html#fetch:~:text=The%20implementation%20is%20based%20upon%20undici), and the TypeError is [thrown here](https://github.com/nodejs/undici/blob/main/lib/web/fetch/request.js#L507)

Currently if GET request based APIs are broken because the default body has an empty string, resulting in a TypeError of "Request with GET/HEAD method cannot have body." being thrown.

Changing the default body on the request to `null` fixes this bug.

I considered updating the condition to check the request method, but figured that without changing the UI it may be confusing to an admin if they're setting a body and it's not being used.